### PR TITLE
Adding support for acts_as_taggable_on latest

### DIFF
--- a/lib/redmine_acts_as_taggable_on/migration.rb
+++ b/lib/redmine_acts_as_taggable_on/migration.rb
@@ -1,4 +1,9 @@
-require 'generators/acts_as_taggable_on/migration/templates/active_record/migration'
+require "bundler"
+require "bundler/cli"
+require "bundler/cli/common"
+
+acts_as_taggable_on_path = Bundler::CLI::Common.select_spec("acts-as-taggable-on").full_gem_path
+require File.join acts_as_taggable_on_path, 'db/migrate/1_acts_as_taggable_on_migration'
 
 class RedmineActsAsTaggableOn::Migration < ActsAsTaggableOnMigration
   class SchemaMismatchError < StandardError; end

--- a/lib/redmine_acts_as_taggable_on/version.rb
+++ b/lib/redmine_acts_as_taggable_on/version.rb
@@ -1,3 +1,3 @@
 module RedmineActsAsTaggableOn
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
Hi, @alexbevi.
I try to update redmine_knowledgebase on redmine-3.0.0.

In that process, redmine_acts_as_taggable_on doesn't work in latest acts_as_taggable_on
because acts_as_taggable_on moves ActsAsTabbableOnMigration class.

So, I changed reference file using bundler and my custom redmine_knowledgebase work well now.
I struggled finding better code, but I have not good idea.
I hope you to check this PR.

Best regards,
